### PR TITLE
Permitir que apenas administradores possam visualizar o botão de iniciar licitação

### DIFF
--- a/src/lib/core/modules/ability.js
+++ b/src/lib/core/modules/ability.js
@@ -10,6 +10,10 @@ const ability = {
   get user() {
     return store.get('user')
   },
+  
+  isGeneral() {
+    return this.user['role'] == 'general'
+  },
 
   rules() {
     return this.user['rules']
@@ -48,7 +52,11 @@ const ability = {
   // custom management
 
   canManageIntegration() {
-    return this.user['role'] == 'general'
+    return this.isGeneral()
+  },
+
+  canStartBidding() {
+    return this.isGeneral()
   }
 }
 

--- a/src/views/biddings/show.vue
+++ b/src/views/biddings/show.vue
@@ -111,7 +111,7 @@
                 .button.button-secondary.u-full-width(@click="showRefuseOverlay = true")
                   | {{ $t('.button.refuse') }}
 
-              .button.button-primary.u-full-width(v-if="bidding.status == 'approved' && $ability.canManage('Bidding')" @click="startBidding(bidding)")
+              .button.button-primary.u-full-width(v-if="bidding.status == 'approved' && $ability.canManage('Bidding') && $ability.canStartBidding()" @click="startBidding(bidding)")
                 | {{ $t('.button.start') }}
 
               .button.button-primary.u-full-width(v-else-if="bidding.status == 'ongoing' && $ability.canManage('Bidding')" @click="reviewBidding(bidding)")


### PR DESCRIPTION
Para facilitar os treinamentos foi solicitado a caiena a implementação de um botão para que iniciasse a licitação antes da data de abertura definida na mesma. Este botão hoje está visível para todos os perfil do ambiente admin e tem causado alguns problemas de entendimento por parte da equipe.

Para evitar isso estou propondo a ocultação do botão de iniciar licitação para todos os perfil que não seja o perfil administrador (general).

![image](https://user-images.githubusercontent.com/1784213/89566554-bd88b080-d7f6-11ea-9897-58c0ae963748.png)
_(tela que permite iniciar licitação antes da data de abertura)_