### PR TITLE
Atualiza worker para pedido de atualização de código

### DIFF
--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -13,6 +13,9 @@ if (process.env.NODE_ENV === 'production') {
     },
     updated() {
       console.log('New content is available; please refresh.');
+      if (window.confirm('Nova versão. Atualizar?')) {
+        window.location.reload()
+      }      
     },
     offline() {
       console.log('No internet connection found. App is running in offline mode.');


### PR DESCRIPTION
Adicionando pedido de atualização para novas versões lançadas para não ser necessário utilizar "force refresh" no browser.

Para que essa atualização seja carregada na primeira vez talvez o revisor tenha que fazer um "force refresh" na página (no windows: Tecla WIN + SHIFT + R) e depois deslogar e logar novamente para que os dados da tradução sejam carregados.