### PR TITLE
Correção da máscara dos campos de latitude e longitude

### DIFF
--- a/src/lib/mask.js/mask.js
+++ b/src/lib/mask.js/mask.js
@@ -39,7 +39,8 @@ const globals = {
     '9': { pattern: /\d/, optional: true },
     '#': { pattern: /\d/, recursive: true },
     'A': { pattern: /[a-zA-Z0-9]/ },
-    'S': { pattern: /[a-zA-Z]/ }
+    'S': { pattern: /[a-zA-Z]/ },
+    'M': { pattern: /[-+]/, optional: true }
     /* eslint-enable quote-props */
   },
   clearIfNotMatch: false


### PR DESCRIPTION
Issue: https://github.com/SolucaoOnlineDeLicitacao/sol-admin-frontend/issues/8

---

Adicionado _pattern_ `M` nas regras da máscara para abranger `-` e `+` dos campos de latitude e longitude.

### Antes

![screenshot-localhost_9082-2020 11 09-11_46_07](https://user-images.githubusercontent.com/22406399/98680462-36406100-2340-11eb-9dff-e0c2afd595d2.png)

### Depois

![screenshot-localhost_9082-2020 11 09-11_46_07 (1)](https://user-images.githubusercontent.com/22406399/98680469-393b5180-2340-11eb-8a29-02dba1d5de4b.png)
