### PR TITLE
Correção da máscara de CPF/CNPJ do Fornecedor

### DIFF
--- a/src/views/providers/edit.vue
+++ b/src/views/providers/edit.vue
@@ -42,7 +42,8 @@
               name="provider[document]",
               :error="errors.document",
               :label="documentLabel",
-              :mask="providerMask"
+              :mask="providerMask",
+              :key="provider.type"
             )
 
         .row
@@ -225,14 +226,14 @@
       },
 
       documentLabel() {
-        let type = this.provider_type
+        let type = this.provider.type
 
         if(type == 'Individual') return 'CPF'
         return 'CNPJ'
       },
 
       providerMask() {
-        let type = this.provider_type
+        let type = this.provider.type
 
         if(type == 'Individual') {
           return { mask: '000.000.000-00', options: { reverse: true, clearIfNotMatch: true } }

--- a/src/views/providers/new.vue
+++ b/src/views/providers/new.vue
@@ -57,7 +57,8 @@
               name="provider[document]",
               :error="errors.document",
               :label="documentLabel",
-              :mask="providerMask"
+              :mask="providerMask",
+              :key="provider.type"
             )
 
         AddressFields(:errors="errorsAddress" prefix="provider" :address="address")


### PR DESCRIPTION
Os problemas da máscara de CPF/CNPJ ao criar/editar um Fornecedor no APP do Revisor foram corrigidos.
O componente `input-field` nesse caso, precisa da propriedade `:key` para funcionar adequadamente.